### PR TITLE
Bump V18.8

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -3,14 +3,10 @@
 
 ######### Only These two lines to edit with new version ######
 # next veriosn do not missing to add "" to version number
-version=18.7
+version=18.8
 description="
 What is NEW:
-- Change the way the quick button is selected
-
-ما هو الجديد:
--  تغيير طريقة اختيار الزر السريع
-"
+- [FrontendInfo] Add AGC fallback for unsupported frontends"
 ##############################################################
 
 BACKUPPATH=/tmp/Backup

--- a/usr/lib/enigma2/python/Components/Converter/RaedQuickFrontendInfo2.py
+++ b/usr/lib/enigma2/python/Components/Converter/RaedQuickFrontendInfo2.py
@@ -38,6 +38,27 @@ class RaedQuickFrontendInfo2(Converter, object):
 		else:
 			self.type = self.LOCK
 
+	def getAGC(self):
+		agc = self.source.agc
+		if agc:
+			return agc
+
+		# Some frontends do not expose signal strength through either
+		# DTV_STAT_SIGNAL_STRENGTH or FE_READ_SIGNAL_STRENGTH.  Keep using
+		# the driver's value when available and estimate a display value
+		# from signal quality only as a fallback.
+		snr = self.source.snr
+		if not snr:
+			return agc
+		snr_percent = snr * 100.0 / 65535.0
+		if snr_percent < 35:
+			agc_percent = snr_percent * 1.8
+		elif snr_percent < 70:
+			agc_percent = 63 + ((snr_percent - 35) * 0.8)
+		else:
+			agc_percent = 91 + ((snr_percent - 70) * 0.3)
+		return round(min(100, agc_percent) * self.range / 100.0)
+
 	@cached
 	def getText(self):
 		assert self.type not in (self.LOCK, self.SLOT_NUMBER), "the text output of FrontendInfo cannot be used for lock info"
@@ -49,7 +70,7 @@ class RaedQuickFrontendInfo2(Converter, object):
 			else:
 				return "N/A"
 		elif self.type == self.AGC:
-			percent = self.source.agc
+			percent = self.getAGC()
 		elif self.type == self.SNR:
 			percent = self.source.snr
 		elif self.type == self.SNRdB:
@@ -88,11 +109,11 @@ class RaedQuickFrontendInfo2(Converter, object):
 		assert self.type != self.LOCK, "the value/range output of FrontendInfo can not be used for lock info"
 		_local = 0
 		if self.type == self.AGC:
-			return self.source.agc or 0
+			return self.getAGC() or 0
 		elif self.type == self.AGC_ANALOG:
-			if self.source.agc is None:
+			if self.getAGC() is None:
 				return 50
-			_local = int(((self.source.agc * 60) / 65536.0) / 3)
+			_local = int(((self.getAGC() * 60) / 65536.0) / 3)
 			if _local < 10:
 				return _local + 50
 			elif _local >= 10:

--- a/usr/lib/enigma2/python/Plugins/Extensions/RaedQuickSignal/tools/version
+++ b/usr/lib/enigma2/python/Plugins/Extensions/RaedQuickSignal/tools/version
@@ -1,4 +1,4 @@
 # RAED(fairbird)
 # Support (www.tunisia-sat.com)
 
-version=18.7
+version=18.8


### PR DESCRIPTION
[FrontendInfo] Add AGC fallback for unsupported frontends
Use the signal power reported by the DVB driver when available.
If the frontend does not provide a signal strength value, estimate
the AGC display value from the signal quality.

This restores the AGC display on Dreamboxes and other affected models
without overriding valid driver values.

cherry-picked > https://github.com/openatv/enigma2/commit/1ed7c34ac34f85fce77b42f67986d5b2d15f0744